### PR TITLE
feat: Make IP address and serial port configurable

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -14,7 +14,7 @@ This file contains numerous blocks of constants that define the robot's physical
 
 *   **UDP Configuration:** Defines the IP, Port, and buffer size for the main command server.
 *   **Servo Configuration:** Contains critical hardware numbers, such as the number of logical joints vs. physical servos and the mapping of their hardware IDs. It also defines default motion parameters like `DEFAULT_PROFILE_VELOCITY` and the `CORRECTION_KP_GAIN` for the closed-loop controller.
-*   **Serial Port Configuration:** Defines the device path (`/dev/ttyAMA0`) and baud rate for the serial connection to the servos.
+*   **Serial Port Configuration:** Defines the default device path (`/dev/ttyAMA0`) and baud rate for the serial connection to the servos. The serial port can be overridden at runtime by using the `--serial-port` command-line argument when running `run_controller.py`. For example: `python run_controller.py --serial-port /dev/ttyUSB0`
 *   **Calibration Inputs (`LOGICAL_JOINT_MASTER_OFFSETS_RAD`):** Provides a high-level software offset for each joint to fine-tune the arm's zero position.
 *   **Joint Limits (`LOGICAL_JOINT_LIMITS_RAD`, `URDF_JOINT_LIMITS`):** Defines the safe range of motion for each joint. These values are used to program the hardware limits on the servos themselves.
 *   **Effective Mapping Ranges:** Defines the expected range of motion in radians for each servo, which is used in the radian-to-raw-value conversion.

--- a/src/gradient_os/run_controller.py
+++ b/src/gradient_os/run_controller.py
@@ -6,6 +6,7 @@ import traceback
 import sys
 import os
 import numpy as np # Added for gripper angle conversion
+import argparse
 
 try:
     from .arm_controller import (
@@ -20,7 +21,7 @@ except ImportError as e:
     sys.exit(1)
 
 
-def main():
+def main(serial_port):
     """
     Main entry point for the robot controller.
 
@@ -33,6 +34,10 @@ def main():
     5. Manages a simple calibration mode for streaming servo data.
     6. Ensures a graceful shutdown of the serial port on exit.
     """
+    # Update the serial port from the command line argument
+    if serial_port:
+        utils.SERIAL_PORT = serial_port
+
     # Initialize the hardware
     servo_driver.initialize_servos()
     servo_driver.set_servo_angle_limits_from_urdf()
@@ -409,5 +414,9 @@ def main():
             print("[Controller] Serial port closed.")
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description='Robot Arm Controller')
+    parser.add_argument('--serial-port', type=str, default='/dev/ttyAMA0',
+                        help='The serial port to connect to the robot arm.')
+    args = parser.parse_args()
+    main(args.serial_port)
 

--- a/src/gradient_os/ui_start.py
+++ b/src/gradient_os/ui_start.py
@@ -9,6 +9,7 @@
 # The pages are switched by calling the switch_to_home, switch_to_editor, switch_to_simulation, switch_to_dashboard, switch_to_workflow, switch_to_welding, switch_to_control, and switch_to_real_control functions.
 
 import sys
+import argparse
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QStackedWidget, QWidget, QVBoxLayout, QHBoxLayout,
     QPushButton, QLabel, QTextEdit, QTableWidget, QTableWidgetItem, QListWidget,
@@ -1175,7 +1176,7 @@ class RealControlPage(QWidget):
         self.parent.send_command(f"ROTATE,{input_str}")
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self, pi_ip="ai-pi.local"):
         super().__init__()
         self.setWindowTitle("Industrial Robot Controller")
         self.setGeometry(50, 50, 1280, 800)
@@ -1200,7 +1201,7 @@ class MainWindow(QMainWindow):
         self.statusBar().addPermanentWidget(estop_btn)
 
         # --- UDP Configuration ---
-        self.PI_IP = "ai-pi.local"
+        self.PI_IP = pi_ip
         self.UDP_PORT = 3000
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
@@ -1356,6 +1357,11 @@ class MainWindow(QMainWindow):
         super().closeEvent(event)
 
 def main():
+    parser = argparse.ArgumentParser(description='Robot Arm UI')
+    parser.add_argument('--pi-ip', type=str, default='ai-pi.local',
+                        help='The IP address of the Raspberry Pi.')
+    args = parser.parse_args()
+
     app = QApplication(sys.argv)
     app.setFont(QFont('Courier New', 12))
     app.setStyleSheet("""
@@ -1406,7 +1412,7 @@ def main():
         max-height: 40px;
     }
     """)
-    window = MainWindow()
+    window = MainWindow(pi_ip=args.pi_ip)
     window.show()
     print('App created')
     print('Stylesheet set')

--- a/udp_client.py
+++ b/udp_client.py
@@ -1,6 +1,7 @@
 import socket
 import time
 import math
+import argparse
 
 # =============================================================================
 #                              CONFIGURATION
@@ -266,6 +267,12 @@ def main():
     print("UDP client closed.")
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Robot Arm UDP Client')
+    parser.add_argument('--pi-ip', type=str, default='ai-pi.local',
+                        help='The IP address of the Raspberry Pi.')
+    args = parser.parse_args()
+    PI_IP = args.pi_ip
+
     # Import numpy for the square test, but don't make it a hard requirement
     # for the whole script.
     try:
@@ -276,4 +283,5 @@ if __name__ == "__main__":
         def run_test_square_sequence():
             print("ERROR: Cannot run 'test_square' because numpy is not installed.")
 
-    main() 
+    main()
+ 


### PR DESCRIPTION
Removes the hard-coded values for the Raspberry Pi's IP address ("ai-pi.local") and the serial port ("/dev/ttyAMA0").

This makes the application more flexible and runnable on different Linux setups where these values may vary.

- The UI (`ui_start.py`) and the UDP client (`udp_client.py`) now accept a `--pi-ip` command-line argument.

- The arm controller (`run_controller.py`) now accepts a `--serial-port` command-line argument.

- Documentation has been updated to reflect these new options.
