### PR TITLE
feat(cli): Improve orientation controls and UI feedback

### DIFF
--- a/src/gradient_os/arm_controller/command_api.py
+++ b/src/gradient_os/arm_controller/command_api.py
@@ -1,4 +1,4 @@
-# Contains the high-level command handlers that parse and react to UDP messages. 
+# Contains the high-level command handlers that parse and react to UDP messages.
 import os
 import json
 import time
@@ -844,6 +844,41 @@ def handle_get_position(sock: 'socket.socket', addr: tuple):
         except Exception as e:
             print(f"[Pi] Error sending FK_FAILED error to {addr}: {e}")
 
+def handle_get_orientation(sock: 'socket.socket', addr: tuple):
+    """
+    Handles the 'GET_ORIENTATION' command.
+    Calculates the current end-effector orientation (as a rotation matrix) using FK
+    and sends it back to the requester.
+    """
+    print(f"[Pi] Received GET_ORIENTATION from {addr}.")
+
+    current_angles = utils.current_logical_joint_angles_rad
+
+    # Get the current orientation using Forward Kinematics
+    current_pose_matrix = ik_solver.get_fk_matrix(current_angles)
+
+    if current_pose_matrix is not None:
+        current_orientation = current_pose_matrix[:3, :3]
+        
+        # Round the orientation matrix for cleaner display
+        orientation_rounded = np.round(current_orientation, 4)
+
+        orientation_str = ",".join(map(str, orientation_rounded.flatten()))
+
+        print(f"[Pi] Sending orientation: {orientation_str}")
+
+        reply_msg = f"CURRENT_ORIENTATION,{orientation_str}"
+
+        try:
+            sock.sendto(reply_msg.encode("utf-8"), addr)
+        except Exception as e:
+            print(f"[Pi] Error sending CURRENT_ORIENTATION to {addr}: {e}")
+    else:
+        print("[Pi] ERROR: Could not calculate current orientation (FK failed).")
+        try:
+            sock.sendto("ERROR,FK_FAILED".encode("utf-8"), addr)
+        except Exception as e:
+            print(f"[Pi] Error sending FK_FAILED error to {addr}: {e}")
 
 def handle_move_line(target_x: float, target_y: float, target_z: float, velocity: float, acceleration: float, closed_loop: bool = True):
     """Convenience wrapper that calls the main profiled move handler, defaulting to closed-loop."""
@@ -1244,4 +1279,3 @@ def _load_trajectory_by_name(name: str):
         print(f"[Pi Trajectory] ERROR: Could not load fallback trajectories.json: {e}")
 
     return None
-

--- a/src/gradient_os/cli_controller.py
+++ b/src/gradient_os/cli_controller.py
@@ -6,6 +6,7 @@ import time
 import argparse
 import sys
 import numpy as np
+from scipy.spatial.transform import Rotation as R
 
 # --- Constants ---
 DEFAULT_CONTROLLER_IP = "mini-arm.local"
@@ -30,10 +31,11 @@ class UDPClient:
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.settimeout(1.0)
         self.position_xyz = [0.0, 0.0, 0.0]
+        self.orientation_rpy_deg = [0.0, 0.0, 0.0]
         self.lock = threading.Lock()
         self.running = True
         
-        self.position_thread = threading.Thread(target=self._fetch_position, daemon=True)
+        self.position_thread = threading.Thread(target=self._fetch_state, daemon=True)
         self.position_thread.start()
 
     def _send_command_locked(self, command):
@@ -71,10 +73,11 @@ class UDPClient:
                 self.sock.settimeout(1.0)
         return 0.0
 
-    def _fetch_position(self):
-        """Periodically sends GET_POSITION and updates the internal state."""
+    def _fetch_state(self):
+        """Periodically sends GET_POSITION and GET_ORIENTATION and updates the internal state."""
         while self.running:
-            with self.lock: # Lock for the entire transaction
+            # --- Get Position ---
+            with self.lock:
                 self._send_command_locked("GET_POSITION")
                 try:
                     data, _ = self.sock.recvfrom(1024)
@@ -88,12 +91,39 @@ class UDPClient:
                 except Exception:
                     pass # Ignore other errors for now
             
+            if not self.running:
+                break
+            time.sleep(0.02) # Small pause between requests
+
+            # --- Get Orientation ---
+            with self.lock:
+                self._send_command_locked("GET_ORIENTATION")
+                try:
+                    data, _ = self.sock.recvfrom(1024)
+                    response = data.decode('utf-8')
+                    if response.startswith("CURRENT_ORIENTATION,"):
+                        parts = response.split(',')
+                        if len(parts) >= 10:
+                            flat_matrix = [float(p) for p in parts[1:10]]
+                            rot_matrix = np.array(flat_matrix).reshape((3, 3))
+                            r = R.from_matrix(rot_matrix)
+                            self.orientation_rpy_deg = r.as_euler('xyz', degrees=True)
+                except socket.timeout:
+                    pass
+                except Exception:
+                    pass
+            
             time.sleep(POSITION_REQUEST_INTERVAL_S)
 
     def get_position(self):
         """Returns the last known position in a thread-safe way."""
         with self.lock:
             return self.position_xyz
+
+    def get_orientation(self):
+        """Returns the last known orientation in a thread-safe way."""
+        with self.lock:
+            return self.orientation_rpy_deg
 
     def close(self):
         self.running = False
@@ -136,11 +166,15 @@ class CLI_UI:
         pos_str = f"Position (X,Y,Z): {pos[0]:.3f}, {pos[1]:.3f}, {pos[2]:.3f}"
         self.stdscr.addstr(3, 2, pos_str, curses.color_pair(1))
 
+        orient = self.client.get_orientation()
+        orient_str = f"Orient (R,P,Y): {orient[0]:.1f}, {orient[1]:.1f}, {orient[2]:.1f}"
+        self.stdscr.addstr(4, 2, orient_str, curses.color_pair(1))
+
         gripper_str = f"Gripper Angle: {self.gripper_angle:.1f}° (0-120)"
-        self.stdscr.addstr(4, 2, gripper_str, curses.color_pair(1))
+        self.stdscr.addstr(5, 2, gripper_str, curses.color_pair(1))
 
         # Instructions
-        y = 6
+        y = 7
         self.stdscr.addstr(y, 2, "--- Controls ---", curses.A_UNDERLINE)
         
         if self.mode == 'pan':
@@ -148,7 +182,7 @@ class CLI_UI:
             self.stdscr.addstr(y+2, 4, "[A] Left (-Y)      [D] Right (+Y)")
             self.stdscr.addstr(y+3, 4, "[Shift+W] Up (+Z)  [Shift+S] Down (-Z)")
         else: # orient
-            self.stdscr.addstr(y+1, 4, "[W] Pitch Up (+Y)  [S] Pitch Down (-Y)")
+            self.stdscr.addstr(y+1, 4, "[W] Pitch Down (-Y)  [S] Pitch Up (+Y)")
             self.stdscr.addstr(y+2, 4, "[A] Yaw Left (+Z)  [D] Yaw Right (-Z)")
             self.stdscr.addstr(y+3, 4, "[Shift+W] Roll (+) [Shift+S] Roll (-)")
 
@@ -168,6 +202,41 @@ class CLI_UI:
 
         self.stdscr.refresh()
 
+    def _handle_pan_input(self, key):
+        """Handles keyboard input for panning mode."""
+        pan_map = {
+            ord('w'): f"MOVE_LINE_RELATIVE,{PAN_STEP_M},0,0",
+            ord('s'): f"MOVE_LINE_RELATIVE,{-PAN_STEP_M},0,0",
+            ord('a'): f"MOVE_LINE_RELATIVE,0,{PAN_STEP_M},0",
+            ord('d'): f"MOVE_LINE_RELATIVE,0,{-PAN_STEP_M},0",
+            ord('W'): f"MOVE_LINE_RELATIVE,0,0,{PAN_STEP_M}",
+            ord('S'): f"MOVE_LINE_RELATIVE,0,0,{-PAN_STEP_M}",
+        }
+        return pan_map.get(key)
+
+    def _handle_orient_input(self, key):
+        """Handles keyboard input for orientation mode."""
+        orient_map = {
+            ord('w'): (0, 1, 0),  # Pitch Up (+Y)
+            ord('s'): (0, -1, 0), # Pitch Down (-Y)
+            ord('a'): (0, 0, 1),  # Yaw Left (+Z)
+            ord('d'): (0, 0, -1), # Yaw Right (-Z)
+            ord('W'): (1, 0, 0),  # Roll + (+X)
+            ord('S'): (-1, 0, 0), # Roll - (-X)
+        }
+        delta = orient_map.get(key)
+        if delta is None:
+            return None
+
+        current_rpy = self.client.get_orientation()
+        new_rpy = [
+            current_rpy[0] + delta[0] * ORIENT_STEP_DEG,
+            current_rpy[1] + delta[1] * ORIENT_STEP_DEG,
+            current_rpy[2] + delta[2] * ORIENT_STEP_DEG,
+        ]
+        # Use a short duration for responsive jogging
+        return f"SET_ORIENTATION,{new_rpy[0]},{new_rpy[1]},{new_rpy[2]},duration_s=0.2"
+
     def _handle_input(self, key):
         cmd = None
         if key in [ord('q'), ord('Q')]:
@@ -176,40 +245,30 @@ class CLI_UI:
         # Mode switching
         if key == ord('\t') or key == 9:
             self.mode = 'orient' if self.mode == 'pan' else 'pan'
-        
-        # Presets
-        elif key == ord('1'):
-            cmd = ",".join(map(str, POS_REST))
-        elif key == ord('2'):
-            cmd = ",".join(map(str, POS_HOME))
-        elif key == ord('3'):
-            cmd = ",".join(map(str, POS_ZERO))
+            return True
+
+        # Key-to-command mapping for simple cases
+        simple_commands = {
+            ord('1'): ",".join(map(str, POS_REST)),
+            ord('2'): ",".join(map(str, POS_HOME)),
+            ord('3'): ",".join(map(str, POS_ZERO)),
+        }
+        cmd = simple_commands.get(key)
 
         # Gripper controls
-        elif key in [ord('r'), ord('R')]:
+        if key in [ord('r'), ord('R')]:
             self.gripper_angle = min(120.0, self.gripper_angle + GRIPPER_STEP_DEG)
             cmd = f"SET_GRIPPER,{self.gripper_angle}"
         elif key in [ord('f'), ord('F')]:
             self.gripper_angle = max(0.0, self.gripper_angle - GRIPPER_STEP_DEG)
             cmd = f"SET_GRIPPER,{self.gripper_angle}"
 
-        # Movement
-        elif self.mode == 'pan':
-            if key == ord('w'): cmd = f"MOVE_LINE_RELATIVE,{PAN_STEP_M},0,0"
-            elif key == ord('s'): cmd = f"MOVE_LINE_RELATIVE,{-PAN_STEP_M},0,0"
-            elif key == ord('a'): cmd = f"MOVE_LINE_RELATIVE,0,{PAN_STEP_M},0"
-            elif key == ord('d'): cmd = f"MOVE_LINE_RELATIVE,0,{-PAN_STEP_M},0"
-            # Shift combinations might not be standard; check for uppercase
-            elif key == ord('W'): cmd = f"MOVE_LINE_RELATIVE,0,0,{PAN_STEP_M}"
-            elif key == ord('S'): cmd = f"MOVE_LINE_RELATIVE,0,0,{-PAN_STEP_M}"
-        
-        elif self.mode == 'orient':
-            if key == ord('w'): cmd = f"ROTATE,y,{ORIENT_STEP_DEG}"
-            elif key == ord('s'): cmd = f"ROTATE,y,{-ORIENT_STEP_DEG}"
-            elif key == ord('a'): cmd = f"ROTATE,z,{ORIENT_STEP_DEG}"
-            elif key == ord('d'): cmd = f"ROTATE,z,{-ORIENT_STEP_DEG}"
-            elif key == ord('W'): cmd = f"ROTATE,x,{ORIENT_STEP_DEG}"
-            elif key == ord('S'): cmd = f"ROTATE,x,{-ORIENT_STEP_DEG}"
+        # Mode-dependent movement
+        if cmd is None:
+            if self.mode == 'pan':
+                cmd = self._handle_pan_input(key)
+            else: # orient
+                cmd = self._handle_orient_input(key)
 
         if cmd:
             err = self.client.send_command(cmd)

--- a/src/gradient_os/run_controller.py
+++ b/src/gradient_os/run_controller.py
@@ -207,6 +207,9 @@ def main():
                 elif command == "GET_POSITION":
                     command_api.handle_get_position(sock, addr)
 
+                elif command == "GET_ORIENTATION":
+                    command_api.handle_get_orientation(sock, addr)
+
                 elif command == "GET_STATUS":
                     reply = f"STATUS,gripper_present,{utils.gripper_present}"
                     sock.sendto(reply.encode("utf-8"), addr)


### PR DESCRIPTION
This commit overhauls the manual orientation controls in the CLI to provide a smoother and more intuitive user experience.

Key changes:
- Replaces the legacy `ROTATE` command with the `SET_ORIENTATION` command for all orientation adjustments. This uses a smoother, pre-planned motion profile.
- Adds a real-time display for the robot's current orientation (Roll, Pitch, Yaw) to the CLI status panel.
- Refactors the key input handler into separate, mode-specific functions (`_handle_pan_input`, `_handle_orient_input`) to improve code clarity and maintainability.
- Corrects the labels for the pitch controls in the UI help text to match their actual function.
